### PR TITLE
Use byte buffer when writing to file in IpGeocoderImpl

### DIFF
--- a/ip-geocoder/src/main/java/com/liferay/ip/geocoder/internal/IPGeocoderImpl.java
+++ b/ip-geocoder/src/main/java/com/liferay/ip/geocoder/internal/IPGeocoderImpl.java
@@ -183,10 +183,11 @@ public class IPGeocoderImpl implements IPGeocoder {
 
 			try {
 
-				int i = 0;
+				int readBytes;
+				byte[] buffer = new byte[4096];
 
-				while ((i = bufferedInputStream.read()) != -1) {
-					bufferedOutputStream.write(i);
+				while ((readBytes = bufferedInputStream.read(buffer)) != -1) {
+					bufferedOutputStream.write(buffer, 0, readBytes);
 				}
 			}
 			finally {

--- a/ip-geocoder/src/main/java/com/liferay/ip/geocoder/internal/IPGeocoderImpl.java
+++ b/ip-geocoder/src/main/java/com/liferay/ip/geocoder/internal/IPGeocoderImpl.java
@@ -176,18 +176,26 @@ public class IPGeocoderImpl implements IPGeocoder {
 		BufferedInputStream bufferedInputStream = new BufferedInputStream(
 			inputStream);
 
-		BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(
-			new FileOutputStream(file));
+		try {
 
-		int i = 0;
+			BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(
+					new FileOutputStream(file));
 
-		while ((i = bufferedInputStream.read()) != -1) {
-			bufferedOutputStream.write(i);
+			try {
+
+				int i = 0;
+
+				while ((i = bufferedInputStream.read()) != -1) {
+					bufferedOutputStream.write(i);
+				}
+			}
+			finally {
+				bufferedOutputStream.close();
+			}
 		}
-
-		bufferedOutputStream.flush();
-
-		bufferedInputStream.close();
+		finally {
+			bufferedInputStream.close();
+		}
 	}
 
 	private static final Logger _logger = Logger.getLogger(


### PR DESCRIPTION
Copying files one byte at a time causes a method call overhead.

Based on the anecdotical profiling, this does not seem to affect the performance of JIT-ed code all that much in the usual use case. But if the code is heavily instrumented, say by JRebel, this overhead is significant.